### PR TITLE
Remove outdated info from plugin starter kit

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,9 @@ But that is just to help you get started! To make it your own:
 - [ ] Optional: Add a `logo.png` file to give this plugin its own logo.
 - [ ] Create a README.MD for your plugin which follows [our documentation guidelines](https://posthog.com/docs/plugins/build). 
 
-If you're looking for inspiration, here are a few exemplary plugins:
+If you're looking for inspiration, then check out plugins source code from [data pipelines](https://posthog.com/docs/cdp).
 
-1. [Hello World](https://github.com/PostHog/helloworldplugin) – basic event processing, with tests
-1. [S3 Export](https://github.com/PostHog/s3-export-plugin) – event export using the AWS SDK, with TypeScript
-1. [GeoIP](https://github.com/PostHog/posthog-plugin-geoip) – advanced event processing using the GeoIP feature, with tests, formatting, linting, TypeScript, and GitHub Actions CI
-1. [PagerDuty](https://github.com/PostHog/posthog-pagerduty-plugin) – periodic job using external HTTP API access
-
-To get up to speed with the environment of plugins, check out [our Plugins overview in PostHog Docs](https://posthog.com/docs/plugins/build/overview).  
-For a crash course, read [the Plugins tutorial in PostHog Docs](https://posthog.com/docs/plugins/build/tutorial).
+To get up to speed with the environment of plugins, check out [our Plugins overview in PostHog Docs](https://posthog.com/docs/plugins/build/overview).
 
 ## Installation
 
@@ -33,12 +27,6 @@ For a crash course, read [the Plugins tutorial in PostHog Docs](https://posthog.
 
 When you're done, you can submit your plugin to our integration library so that it can be used by other users, including those on PostHog Cloud. 
 
-To submit your plugin, [email your plugin GitHub URL to hey@posthog.com](mailto:hey@posthog.com?subject=Submit%20Plugin%20to%20Repository&body=Plugin%20GitHub%20link%3A)
+To submit your plugin, use the support option in PostHog Cloud.
 
-Once we get your email, we'll review the plugin to ensure it's secure, performant, and adheres to best practices. Then, we add it to our official repository and make it available for everyone to use!
-
-## Questions?
-
-### [Join our Slack community.](https://join.slack.com/t/posthogusers/shared_invite/enQtOTY0MzU5NjAwMDY3LTc2MWQ0OTZlNjhkODk3ZDI3NDVjMDE1YjgxY2I4ZjI4MzJhZmVmNjJkN2NmMGJmMzc2N2U3Yjc3ZjI5NGFlZDQ)
-
-We're here to help you with anything PostHog!
+We'll review the plugin to ensure it's secure, performant, and adheres to best practices and isn't already accomplisahable by other ways. Then, we add it to our official repository and make it available for everyone to use!

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ But that is just to help you get started! To make it your own:
 - [ ] Optional: Add a `logo.png` file to give this plugin its own logo.
 - [ ] Create a README.MD for your plugin which follows [our documentation guidelines](https://posthog.com/docs/plugins/build). 
 
-If you're looking for inspiration, then check out plugins source code from [data pipelines](https://posthog.com/docs/cdp).
+If you're looking for inspiration, then check out existing plugins and their source code from [data pipelines](https://posthog.com/docs/cdp).
 
 To get up to speed with the environment of plugins, check out [our Plugins overview in PostHog Docs](https://posthog.com/docs/plugins/build/overview).
 
@@ -29,4 +29,4 @@ When you're done, you can submit your plugin to our integration library so that 
 
 To submit your plugin, use the support option in PostHog Cloud.
 
-We'll review the plugin to ensure it's secure, performant, and adheres to best practices and isn't already accomplisahable by other ways. Then, we add it to our official repository and make it available for everyone to use!
+We'll review the plugin to ensure it's secure, performant, adheres to best practices and isn't already doing something that can be accomplished by other means. Then we'll add it to our official repository and make it available for everyone to use!

--- a/index.js
+++ b/index.js
@@ -1,22 +1,6 @@
-// <TODO: your plugin code here - you can base it on the code below, but you don't have to>
-
-// Some internal library function
-async function getRandomNumber() {
-    return 4
-}
-
-// Plugin method that runs on plugin load
-export async function setupPlugin({ config }) {
-    console.log(`Setting up the plugin`)
-}
-
-// Plugin method that processes event
-export async function processEvent(event, { config, cache }) {
-    const counterValue = (await cache.get('greeting_counter', 0))
-    cache.set('greeting_counter', counterValue + 1)
+// Example plugin method for modifying events
+export function processEvent(event, { config }) {
     if (!event.properties) event.properties = {}
     event.properties['greeting'] = config.greeting
-    event.properties['greeting_counter'] = counterValue
-    event.properties['random_number'] = await getRandomNumber()
     return event
 }


### PR DESCRIPTION
cache isn't allowed and processEvent should be non-async
the example plugins will inevitably get outdated here so just linked to docs with options.
we don't provide email support anymore.

